### PR TITLE
feat(client): error boundary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>May the force be with you!</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,18 @@
 import "./App.css";
-import { Route } from "wouter";
+import { Route, Switch } from "wouter";
 import PlanetsList from "./PlanetsList";
 import PlanetDetails from "./PlanetDetails";
+import ErrorPage from "./ErrorPage";
 
 function App() {
   return (
-    <div>
+    <Switch>
       <Route path='/planet/:planetId' component={PlanetDetails} />
       <Route path='/planets/:pageNumber' component={PlanetsList} />
       <Route path='/planets' component={PlanetsList} />
       <Route path='/' component={PlanetsList} />
-    </div>
+      <Route component={ErrorPage} />
+    </Switch>
   );
 }
 

--- a/src/ErrorPage.tsx
+++ b/src/ErrorPage.tsx
@@ -1,0 +1,17 @@
+import { useLocation } from "wouter";
+
+const ErrorPage: React.FC = () => {
+  const [, setLocation] = useLocation();
+
+  // Error boundary for mismatched routes
+  return (
+    <div style={{ margin: "8px" }}>
+      <div style={{ fontWeight: "bold", margin: "16px" }}>
+        This is not the page you're searching for...
+      </div>
+      <button onClick={() => setLocation("/planets/")}>Back to planets</button>
+    </div>
+  );
+};
+
+export default ErrorPage;


### PR DESCRIPTION
adds an `ErrorPage` to handle mismatched routes, let's a user return to the planets page